### PR TITLE
Potential fix for code scanning alert no. 4: Use of a known vulnerable action.

### DIFF
--- a/.github/workflows/master_prod-api.yml
+++ b/.github/workflows/master_prod-api.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4.1.7
         with:
           name: .net-app
 


### PR DESCRIPTION
Potential fix for [https://github.com/simonthurman/productsapi/security/code-scanning/4](https://github.com/simonthurman/productsapi/security/code-scanning/4)

To fix the problem, we need to update the `actions/download-artifact` action to a non-vulnerable version. The recommended version to update to is `v4.1.7`. This change will ensure that the workflow is not using a version of the action with known vulnerabilities, thereby improving the security of the workflow and the repository.

The specific change required is to update the version of the `actions/download-artifact` action in the `.github/workflows/master_prod-api.yml` file from `v2` to `v4.1.7`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
